### PR TITLE
Add AnonCreds context and adjust output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/W3COutput/W3C-VC-ComplexProof.json
+++ b/W3COutput/W3C-VC-ComplexProof.json
@@ -1,68 +1,87 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://anoncreds.example/spec/v1"
+    "https://raw.githubusercontent.com/andrewwhitehead/anoncreds-w3c-mapping/main/schema.json"
   ],
   "type": [
     "VerifiableCredential",
     "AnonCredsPresentation"
   ],
   "issuer": "self",
-  "issuanceDate": "2022-10-28T21:33:36Z",
+  "issuanceDate": "2022-11-08T19:24:11Z",
   "credentialSubject": [
     {
       "index": 0,
       "issuer": "did:sov:CsQY9MGeD3CQP4EyuVFo5m",
-      "schema": "CsQY9MGeD3CQP4EyuVFo5m:2:MYCO Biomarker:0.0.3",
+      "schema": "CsQY9MGeD3CQP4EyuVFo5m:2:MYCO%20Biomarker:0.0.3",
       "definition": "CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker",
-      "revealed": {
-        "researcher_share": "bf712cb328a92862b57f0dc806dec12a",
-        "unit": "\u03bcM",
-        "concentration": "10",
-        "name": "Iron",
-        "range": "9.00-30.0",
-        "collected_on": "2020-07-05",
-        "biomarker_id": "c9ace7dc-0485-4f3f-b466-16a27a80acf1"
-      },
-      "mapping": {
-        "revealedAttributes": {
-          "biomarker_attrs_0": [
-            "researcher_share",
-            "unit",
-            "concentration",
-            "name",
-            "range",
-            "collected_on",
-            "biomarker_id"
-          ]
+      "attribute": {
+        "researcher_share": {
+          "value": "bf712cb328a92862b57f0dc806dec12a"
+        },
+        "unit": {
+          "value": "\u03bcM"
+        },
+        "concentration": {
+          "value": "10"
+        },
+        "name": {
+          "value": "Iron"
+        },
+        "range": {
+          "value": "9.00-30.0"
+        },
+        "collected_on": {
+          "value": "2020-07-05"
+        },
+        "biomarker_id": {
+          "value": "c9ace7dc-0485-4f3f-b466-16a27a80acf1"
         }
       }
     },
     {
       "index": 1,
       "issuer": "did:sov:TUku9MDGa7QALbAJX4oAww",
-      "schema": "FbozHyf7j5q7TDn2s8MXZN:2:MYCO Consent Enablement:0.1.0",
+      "schema": "FbozHyf7j5q7TDn2s8MXZN:2:MYCO%20Consent%20Enablement:0.1.0",
       "definition": "TUku9MDGa7QALbAJX4oAww:3:CL:531757:MYCO_Consent_Enablement",
-      "revealed": {
-        "jti_unique_identifier": "205b1ea0-7848-48d4-b52b-339122d84f62"
-      },
-      "mapping": {
-        "revealedAttributes": {
-          "consent_attrs": "jti_unique_identifier"
+      "attribute": {
+        "jti_unique_identifier": {
+          "value": "205b1ea0-7848-48d4-b52b-339122d84f62"
         }
       }
     }
   ],
   "proof": {
-    "type": "AnonCredsProof2022",
-    "encoding": "auto",
+    "type": "AnonCredsPresentationProof2022",
     "nonce": "182453895158932070575246",
-    "credentials": [
+    "credential": [
       {
-        "eq": "AAEBAnr2QlWJXV6EkhT-h2BNW5hYmX0VwitrytT6GRX49yVS14LyDxDU1-3CzkmvSTTZ5m3WYGUf-gm8fqJEntxgTfyum9bAzMfihaGQPzODGxKl75CRTEcOYHdHQ-3uSx21faiPbH4vrYkXcxoDUKw9oc-NYuRAaY-mes2EKAv7PXmmbAIsTWwxrfq86ea8exoxfyd9HY96yF_LeIwigowg1SHC_qdpk1jlbPk8XEC3vK77WajulVpEIEj3h_HLANIkV4-D0gJ4CSKd-cLGZdiGrXJy_OuOVJioRS0IpWw3Ohb_JJ8NKLhkSUKpjKZRYG4paUQG7lNNAMc9QPHWpCMR1QEBADmfDHTZkqi1GzjEfeVjSu63oycEdKbQamEDPM11dg_02be6cUnKOkVQ3B0JgMzWN1P-8lUkfM0syosCAX8OGuhT8_ZV1o7TKkp4vDaX43upHmYFQf0jC-XHs12W2JEQ_oMbV_tkXwv0aPUPlTLBPlB24-jD6tkawmmBDTA0ePWp3T_RCZ21lJYsDB_oiQaucplMHnxomaJNTDg7TudroYRwh3TV3NOY_gq7i25O4KqZDIIllVuVACSUIP2Yn8OmId05nsYNjEWA8gqXeDe16D7AYO4KKCrUApvahFFsNCqSr9UOEXIILN0IRTEh1KtYHF2GcrBFM6mazQc2Yey7JBVxEwGN5Lt3jGQzbcWns1U3By_VTKQt5pi0eoLuwxQr8Ma8F0q7m17AMWrQ7oyvC5NPIbkmJUldLWZ-UbEs5bWGH0I3aWUp2auXuQKGHc0q4293nQeRcVRhyuhO2qVPkfoLJJl9LZO8gpVSaGXrcbj-1i3i8dHk8euyss3Pyv-HXmgRRVoBeswB-_Jx_lJRdq90g95RdUgpHyULPsX88hUZCDSBAx8wjxphKMKjPgOSuYXP3dM2snmNy0018wMAtQANbWFzdGVyX3NlY3JldABKNpSwp1ZNhmvC5c39st9DdgBJKLrQhsr_mOhZtbZ6NVf4dwgUrcpd6WRYDW3zV-AXn1TOUh92UBgraM_1CiTKVT4tx6v38ErLatcADGNsaWVudF9zaGFyZQBKQt1xHKRmqKNS-wBRJsGlYYtLLWkn-nIa1iWij2vX-TllDxNHemndcw_2FwymDN3A0tYy-2PSORbPdFQOsRp-0sPYdyiYkEoPk8wEAErMaZdyhxg_OfqQPldHiOgS1Rd5bHg5gbgh0IpGutVzSxBRuaqYufBAz-3rkh9SngWzEFy0UhJ-bIIdWFKVWxjU3ePxv_7HoY5pUw"
+        "encoding": "auto",
+        "index": 0,
+        "mapping": {
+          "revealedAttributes": {
+            "biomarker_attrs_0": [
+              "researcher_share",
+              "unit",
+              "concentration",
+              "name",
+              "range",
+              "collected_on",
+              "biomarker_id"
+            ]
+          }
+        },
+        "eqProof": "AAEBAnr2QlWJXV6EkhT-h2BNW5hYmX0VwitrytT6GRX49yVS14LyDxDU1-3CzkmvSTTZ5m3WYGUf-gm8fqJEntxgTfyum9bAzMfihaGQPzODGxKl75CRTEcOYHdHQ-3uSx21faiPbH4vrYkXcxoDUKw9oc-NYuRAaY-mes2EKAv7PXmmbAIsTWwxrfq86ea8exoxfyd9HY96yF_LeIwigowg1SHC_qdpk1jlbPk8XEC3vK77WajulVpEIEj3h_HLANIkV4-D0gJ4CSKd-cLGZdiGrXJy_OuOVJioRS0IpWw3Ohb_JJ8NKLhkSUKpjKZRYG4paUQG7lNNAMc9QPHWpCMR1QEBADmfDHTZkqi1GzjEfeVjSu63oycEdKbQamEDPM11dg_02be6cUnKOkVQ3B0JgMzWN1P-8lUkfM0syosCAX8OGuhT8_ZV1o7TKkp4vDaX43upHmYFQf0jC-XHs12W2JEQ_oMbV_tkXwv0aPUPlTLBPlB24-jD6tkawmmBDTA0ePWp3T_RCZ21lJYsDB_oiQaucplMHnxomaJNTDg7TudroYRwh3TV3NOY_gq7i25O4KqZDIIllVuVACSUIP2Yn8OmId05nsYNjEWA8gqXeDe16D7AYO4KKCrUApvahFFsNCqSr9UOEXIILN0IRTEh1KtYHF2GcrBFM6mazQc2Yey7JBVxEwGN5Lt3jGQzbcWns1U3By_VTKQt5pi0eoLuwxQr8Ma8F0q7m17AMWrQ7oyvC5NPIbkmJUldLWZ-UbEs5bWGH0I3aWUp2auXuQKGHc0q4293nQeRcVRhyuhO2qVPkfoLJJl9LZO8gpVSaGXrcbj-1i3i8dHk8euyss3Pyv-HXmgRRVoBeswB-_Jx_lJRdq90g95RdUgpHyULPsX88hUZCDSBAx8wjxphKMKjPgOSuYXP3dM2snmNy0018wMAtQANbWFzdGVyX3NlY3JldABKNpSwp1ZNhmvC5c39st9DdgBJKLrQhsr_mOhZtbZ6NVf4dwgUrcpd6WRYDW3zV-AXn1TOUh92UBgraM_1CiTKVT4tx6v38ErLatcADGNsaWVudF9zaGFyZQBKQt1xHKRmqKNS-wBRJsGlYYtLLWkn-nIa1iWij2vX-TllDxNHemndcw_2FwymDN3A0tYy-2PSORbPdFQOsRp-0sPYdyiYkEoPk8wEAErMaZdyhxg_OfqQPldHiOgS1Rd5bHg5gbgh0IpGutVzSxBRuaqYufBAz-3rkh9SngWzEFy0UhJ-bIIdWFKVWxjU3ePxv_7HoY5pUw"
       },
       {
-        "eq": "AAEBAaJ19hG1ctE6MUCRF4ZxAFUfk5LImKIcQkKpT5hRNYLBaYWiJbgKRCV3H1PG9d53Oe4nzugeCCg26tNW6zUe1TOIXR1b70NIOXm5T4-AXzw_Qpxa4NnLDYPuEWxcXg3kNn29Ut0ozJEviwGx9FWW878PoR09SH2OzaXGvpAWZ8ZTFlt2MUA5d6_9QEV-jjK52aQQgC7J2Kf1qOUOcbtWYdd5j6sotyQyRPp6-_LzUCbstkS-SqzjV-oBAFq83TBcc0YtBvH91BngNJmpwmydvogcLzecWtd9l06vWWRN_Ve9Mt6edA5ofyQA2uDtCwg06ZqsBBq2BAzKe6VxmF-agSABADk3gQhGDchPC0eanv6DNVaQ3dlmhD6dljbiBxpxnAGmfEvcy7UQJgkFWPpU7kCHFZbRLtpHZrfnIm0CAX8CdS36H3jtUA_JFQRnW1Uc2XuWAjh3QYuQ8M09VMuhja6AqyARhpt_p-vHSraSap1c91H7WBwxbf5on13mX8jfLhy4bBcBE0eH94k2tq6gQeSzn2csCD8I9kyGojZkvADdVVBSnAOwFtE6ocMIGhgPF2L4r1X324DCMjr1HcAVUy79e0msgOPGpXkSsdHDOAcK7RA3SXg4choe3JAce-EGOB2tMyo1TL1jQckGKmcp4NgqC9JClpYaqvGscwijmwz4a1CePtbhcHqtC3AP0n8mYzsZNaDqo6HSXn-jqpxN3ZN-4ID3FE3Y-eGkikf5K7YMbEMeD-RKhKDeCiW5pUlHafOlw-yljmusm7mCsVJkIIB9F7N7M51zKJFbvSq1RQfejlQcQKSstwMNaVpieDR4S_5fNXxDavgLfJwldZUFHk8Xfgb6ib4H4qfSMTeSmO_GlV6GlC19sZcW_mDeOlg8Ai2M4x8iy_3xgPZ5xYq3n4KcRXM69zWicLmluFCA6gMEfAAVaWF0X2NvbnNlbnRfdGltZXN0YW1wAEp9EuGn8-es9xA-0M13816a39BNhz5OiQBoowNKe-dTh5Yw7K7rRa_YSjBHWEVY6q_KyBzqL7Io1BEppOIswkBfWhVYgGEtPepkdwANbWFzdGVyX3NlY3JldABKNpSwp1ZNhmvC5c39st9DdgBJKLrQhsr_mOhZtbZ6NVf4dwgUrcpd6WRYDW3zV-AXn1TOUh92UBgraM_1CiTKVT4tx6v38ErLatcAD2RhdGFfY29udHJvbGxlcgBK_dAJ27qv3UR8oabLOYMx2hXSh3ey4E8ar07JXSfykkVCc1rgm9qH6q0PDSieQOy2L7fz6Hpxiv7RPo1hRDMovmtUdiFjxgoWK9UABm5vdGljZQBKLBLtaMjd6A24-5_qwEimjqnzTEG8Y7X4Q2_8L31cix_8g88FzTQXDn5gftifpWiFGwMLTI9BMaQNl9RAOpUj31i6c6-3pnovyIUACXNlbnNpdGl2ZQBK1gxlDy5a3WVkfR9J7CsFORShzfUbTPLpL76jVrnQYN1DMcEfOVi8LPXKVUgPUmwbMo0m2sxQ63G8xE49hBiofzXX_HDhuAgKe-sACHNlcnZpY2VzAErqtY3y7uBr9HSOWcEwlMcFM8Gi-XN8QvS5kuPEyyhkKOGJ4CKDYrc31Ch_80Ly5LubGLbL38-rd0XB8o2oxPAgjO83HgdIhFZ_hQAWc3ViX3N1YmplY3RfaWRlbnRpZmllcgBKuVtqPAxNbTywD65SJoHo-_DLMAKxP3kKxrvpmFPCTDDSa64J3ox99v88YkJX-Zy2SsQ53crmp1dkSOdBnxmm-731ylVYHZ3p3O0AGG1vY19tZXRob2Rfb2ZfY29sbGVjdGlvbgBKnlpT2EwTHTQ1Ab-L42u17GnM9MnX7tBRAGOgKCJDnup8u-96Y_kJQtgkzogIxnvc7K16fUequwTQ72C1xAMI7SPm4I-Lqakyy4kAHGp1cmlzZGljdGlvbl9kYXRhX3Byb2Nlc3NpbmcASvn__VuPw8WFAYjOmBl_EN6Cu_S8tiKZTBmBnhR6cm5Frn353ow7tbzQX6P53LnMzs8fAynhiSQT5ioRBHRtR5NAIsG44iVC9iUmABtpc3NfaW50ZXJuZXRfcHJvY2Vzc2luZ191cmkASmz9H8nALYor0NYdLcMqrUycFpNiS3k1tRNYQTr_0thtTY9m_MhFNYwWp8e5uXtqVem_qlKW8wL6fkwC9tEje_mJPPsPc4ztXKbEAB12ZXJzaW9uX2NvbnNlbnRfc3BlY2lmaWNhdGlvbgBKeyGh1pJ-ux8al2eENRJ0PgbmT2TVy2ab9_pwMp4NVCED-CQHFh3Wd7T7Sy64Vl35UrXXzsWm_Q08LwAeeOdGoZY_tQH_jKIZXYEACnBvbGljeV91cmwASsFXPFTDatFgiveyss9eGefRI3czecVaZRklTaq_Hd7kP4AQvrE3q450LvuG8XtqtyxiDIXZSPfJ9yxRwzri2Dt57BeK1L8tJqYxBABKZs2MpyOyxshiglchyhYfh5jD7fx6pYajVitQ3FUrF8BqvQGJOBfZYPB19O62RjgOBPMiCk4W1HPqK2QpBgPY4hzwyutfHssNn5k"
+        "encoding": "auto",
+        "index": 1,
+        "mapping": {
+          "revealedAttributes": {
+            "consent_attrs": "jti_unique_identifier"
+          }
+        },
+        "eqProof": "AAEBAaJ19hG1ctE6MUCRF4ZxAFUfk5LImKIcQkKpT5hRNYLBaYWiJbgKRCV3H1PG9d53Oe4nzugeCCg26tNW6zUe1TOIXR1b70NIOXm5T4-AXzw_Qpxa4NnLDYPuEWxcXg3kNn29Ut0ozJEviwGx9FWW878PoR09SH2OzaXGvpAWZ8ZTFlt2MUA5d6_9QEV-jjK52aQQgC7J2Kf1qOUOcbtWYdd5j6sotyQyRPp6-_LzUCbstkS-SqzjV-oBAFq83TBcc0YtBvH91BngNJmpwmydvogcLzecWtd9l06vWWRN_Ve9Mt6edA5ofyQA2uDtCwg06ZqsBBq2BAzKe6VxmF-agSABADk3gQhGDchPC0eanv6DNVaQ3dlmhD6dljbiBxpxnAGmfEvcy7UQJgkFWPpU7kCHFZbRLtpHZrfnIm0CAX8CdS36H3jtUA_JFQRnW1Uc2XuWAjh3QYuQ8M09VMuhja6AqyARhpt_p-vHSraSap1c91H7WBwxbf5on13mX8jfLhy4bBcBE0eH94k2tq6gQeSzn2csCD8I9kyGojZkvADdVVBSnAOwFtE6ocMIGhgPF2L4r1X324DCMjr1HcAVUy79e0msgOPGpXkSsdHDOAcK7RA3SXg4choe3JAce-EGOB2tMyo1TL1jQckGKmcp4NgqC9JClpYaqvGscwijmwz4a1CePtbhcHqtC3AP0n8mYzsZNaDqo6HSXn-jqpxN3ZN-4ID3FE3Y-eGkikf5K7YMbEMeD-RKhKDeCiW5pUlHafOlw-yljmusm7mCsVJkIIB9F7N7M51zKJFbvSq1RQfejlQcQKSstwMNaVpieDR4S_5fNXxDavgLfJwldZUFHk8Xfgb6ib4H4qfSMTeSmO_GlV6GlC19sZcW_mDeOlg8Ai2M4x8iy_3xgPZ5xYq3n4KcRXM69zWicLmluFCA6gMEfAAVaWF0X2NvbnNlbnRfdGltZXN0YW1wAEp9EuGn8-es9xA-0M13816a39BNhz5OiQBoowNKe-dTh5Yw7K7rRa_YSjBHWEVY6q_KyBzqL7Io1BEppOIswkBfWhVYgGEtPepkdwANbWFzdGVyX3NlY3JldABKNpSwp1ZNhmvC5c39st9DdgBJKLrQhsr_mOhZtbZ6NVf4dwgUrcpd6WRYDW3zV-AXn1TOUh92UBgraM_1CiTKVT4tx6v38ErLatcAD2RhdGFfY29udHJvbGxlcgBK_dAJ27qv3UR8oabLOYMx2hXSh3ey4E8ar07JXSfykkVCc1rgm9qH6q0PDSieQOy2L7fz6Hpxiv7RPo1hRDMovmtUdiFjxgoWK9UABm5vdGljZQBKLBLtaMjd6A24-5_qwEimjqnzTEG8Y7X4Q2_8L31cix_8g88FzTQXDn5gftifpWiFGwMLTI9BMaQNl9RAOpUj31i6c6-3pnovyIUACXNlbnNpdGl2ZQBK1gxlDy5a3WVkfR9J7CsFORShzfUbTPLpL76jVrnQYN1DMcEfOVi8LPXKVUgPUmwbMo0m2sxQ63G8xE49hBiofzXX_HDhuAgKe-sACHNlcnZpY2VzAErqtY3y7uBr9HSOWcEwlMcFM8Gi-XN8QvS5kuPEyyhkKOGJ4CKDYrc31Ch_80Ly5LubGLbL38-rd0XB8o2oxPAgjO83HgdIhFZ_hQAWc3ViX3N1YmplY3RfaWRlbnRpZmllcgBKuVtqPAxNbTywD65SJoHo-_DLMAKxP3kKxrvpmFPCTDDSa64J3ox99v88YkJX-Zy2SsQ53crmp1dkSOdBnxmm-731ylVYHZ3p3O0AGG1vY19tZXRob2Rfb2ZfY29sbGVjdGlvbgBKnlpT2EwTHTQ1Ab-L42u17GnM9MnX7tBRAGOgKCJDnup8u-96Y_kJQtgkzogIxnvc7K16fUequwTQ72C1xAMI7SPm4I-Lqakyy4kAHGp1cmlzZGljdGlvbl9kYXRhX3Byb2Nlc3NpbmcASvn__VuPw8WFAYjOmBl_EN6Cu_S8tiKZTBmBnhR6cm5Frn353ow7tbzQX6P53LnMzs8fAynhiSQT5ioRBHRtR5NAIsG44iVC9iUmABtpc3NfaW50ZXJuZXRfcHJvY2Vzc2luZ191cmkASmz9H8nALYor0NYdLcMqrUycFpNiS3k1tRNYQTr_0thtTY9m_MhFNYwWp8e5uXtqVem_qlKW8wL6fkwC9tEje_mJPPsPc4ztXKbEAB12ZXJzaW9uX2NvbnNlbnRfc3BlY2lmaWNhdGlvbgBKeyGh1pJ-ux8al2eENRJ0PgbmT2TVy2ab9_pwMp4NVCED-CQHFh3Wd7T7Sy64Vl35UrXXzsWm_Q08LwAeeOdGoZY_tQH_jKIZXYEACnBvbGljeV91cmwASsFXPFTDatFgiveyss9eGefRI3czecVaZRklTaq_Hd7kP4AQvrE3q450LvuG8XtqtyxiDIXZSPfJ9yxRwzri2Dt57BeK1L8tJqYxBABKZs2MpyOyxshiglchyhYfh5jD7fx6pYajVitQ3FUrF8BqvQGJOBfZYPB19O62RjgOBPMiCk4W1HPqK2QpBgPY4hzwyutfHssNn5k"
       }
     ],
     "aggregated": "AAAgtMR4DrkY--ZVgKHmUANE04ET7TzUxZ0vZmVcNt4nCkwBABUACQJ69kJVIxHVAQAIAaJ19l-agSA"

--- a/W3COutput/W3C-VC-Credential_1.json
+++ b/W3COutput/W3C-VC-Credential_1.json
@@ -1,24 +1,28 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://anoncreds.example/spec/v1"
+    "https://raw.githubusercontent.com/andrewwhitehead/anoncreds-w3c-mapping/main/schema.json"
   ],
   "type": [
     "VerifiableCredential",
     "AnonCredsCredential"
   ],
   "issuer": "did:sov:3avoBCqDMFHFaKUHug9s8W",
-  "issuanceDate": "2022-10-28T21:33:36Z",
+  "issuanceDate": "2022-11-08T19:24:11Z",
   "credentialSchema": {
-    "type": "AnonCredsSchema",
+    "type": "AnonCredsDefinition",
     "schema": "3avoBCqDMFHFaKUHug9s8W:2:fabername:0.1.0",
     "definition": "3avoBCqDMFHFaKUHug9s8W:3:CL:13:default"
   },
   "credentialSubject": {
-    "name": "Alice Jones"
+    "attribute": {
+      "name": {
+        "value": "Alice Jones"
+      }
+    }
   },
   "proof": {
-    "type": "AnonCredsProof2022",
+    "type": "CLSignature2022",
     "encoding": "auto",
     "signature": "AAAgf9w5lZgz95dY38QeT0XWJfaGrY-CSr8uDo82jptOTmUBAQChFsSOFc2fDgVDKCSs2KydOLvZbNLFXyB2qlJGTadW1ZBcZ2WvocXcKufEWrbDbTr58ySW_Om1HUmVy-ojBvh4fwAf6XETclSPE8MfctSE09pwpy4ZYpOabSdY2G6mt4U4j5YdCiuCEBnmiG7JaxgdHqW4cG3kSxX1JXmy2rE8S0uHFxqT3H4d2otX0Om9r9e6btmeA0mv4fqfy9gd9y7cxAE4Xw7nQp5y29yhA93gpHmfV0FNcEzvgmFBGhF5DzMEYGM7Bmoxip3zmlXDpn4Z3Q-SQWKuO1SEa-YPEjc7OkQN8GjEweQAP6zUNoDD7FQtGdhXsJ0gq9tLz_Xw_x3BAgBLEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVC4ox7flXlg7AEkAhB-3AwFVCeRcF6Ii4FMqDfJ04FB_vm7NdqoWcfHARRmFzgUgMYoiB04kz5CDzzIVuowqkIbRgrlC7CKryuzuqNiCF3mfQkvJWfK3qXFNBKp2ZBVxYUo92l0LbE0cBAG3p_ZB26PO5XSS8Nw8U7uWJPkG0rQxreZcgEtw1WFNEzfpiTLN-W4xGneTYqot3VDFMXjmn0i37nPhdSSvfnSkk6PDJWi8H5Op-Zm03f5o6cWTW-vyL0p8x0dcvYGLPxDSLnbeP0Fc95KewHAtfWSn4gdQ7C2fzc8pZ9UV9iUIIDtdhDV306h-ZUhO641o2BTIa3fDQi7X590gIdhYhAUfIarHGzvXdff6OatwALnJqhAY2jbGopyrpgsTb9i7SOYwkztTJbHQ139Syv75uJ1rrGDzm_feXNGvM-ta8sr4sdD51vcOhVlFeDPD3R8iEqNbOGuj6-wJlmyF8CsEAQCBwfG7CL3X9rS6GkDsCmkw18__K8cSaePD4YWFDQHBqnzu6nOIy6RGa8U6tXgJbqZPGcBg9Db6W0iwkub9N36nadgqjPQkhuxt0U8H-p6NkPfbqqjZ3dDqNmDAuvr96_MItOSdPI_kRhyhJK9779Lg6iWyakimJ1QViqsefO-1uE-MQ0FXqs4ZcC-V187LXc2IHpJwk2d8Oo66oQij__Gcn4h0qQf0rC8TNy54_IQTSns080AK7Yfy12nMWBnWJN_7d4CToSpDAehyn2YEBPmweGuVnXu-DEjAbeEGFbsTYsCHygo_yzBpndRguYruDzn2yyt3RkyWISFYRZzEL1xPBQAgeOfJKl30pg6m-np2OmrRYp8Z_x3FqdwRHoWruiF0FlM"
   }

--- a/W3COutput/W3C-VC-UnrevealedProof.json
+++ b/W3COutput/W3C-VC-UnrevealedProof.json
@@ -1,51 +1,56 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://anoncreds.example/spec/v1"
+    "https://raw.githubusercontent.com/andrewwhitehead/anoncreds-w3c-mapping/main/schema.json"
   ],
   "type": [
     "VerifiableCredential",
     "AnonCredsPresentation"
   ],
   "issuer": "self",
-  "issuanceDate": "2022-10-28T21:33:36Z",
+  "issuanceDate": "2022-11-08T19:24:11Z",
   "credentialSubject": [
     {
       "index": 0,
       "issuer": "did:sov:WzXgmpw6yvDdKaRcRnWxan",
-      "schema": "WzXgmpw6yvDdKaRcRnWxan:2:degree schema:75.57.82",
+      "schema": "WzXgmpw6yvDdKaRcRnWxan:2:degree%20schema:75.57.82",
       "definition": "WzXgmpw6yvDdKaRcRnWxan:3:CL:8:faber.agent.degree_schema",
-      "revealed": {
-        "degree": "Maths",
-        "date": "2018-05-28"
-      },
-      "mapping": {
-        "revealedAttributes": {
-          "0_degree_uuid": "degree",
-          "0_date_uuid": "date"
+      "attribute": {
+        "degree": {
+          "value": "Maths"
         },
-        "unrevealedAttributes": {
-          "0_name_uuid": "name"
-        },
-        "requestedPredicates": {
-          "0_birthdate_dateint_GE_uuid": {
-            "index": 0,
-            "attr_name": "birthdate_dateint",
-            "p_type": "<=",
-            "value": 20041012
-          }
+        "date": {
+          "value": "2018-05-28"
         }
       }
     }
   ],
   "proof": {
-    "type": "AnonCredsProof2022",
-    "encoding": "auto",
+    "type": "AnonCredsPresentationProof2022",
     "nonce": "455903554639287921141579",
-    "credentials": [
+    "credential": [
       {
-        "eq": "AAEAzHDfd7FQqeO8P3blJyCIJxiBXrxnWEVdMj6X0JSOPOu_GYQt3gVdbBt7JMo9ZKCIFrat6KVfMMno_jD9i_YRLydG8WegmDI70bvQz4un2TliF7hNo3nTDX_TA1FEuk53zIolm2Vnf3L1HpSeIAFbUjis-2jnQ1xBqbM315Zl6Ve-AKipHlfJ1aqYN5RVOzL-Y8bXmSbsJ0CuFXqCbK9FCPYz8wBKIyRiq7S6QM9yy8RZcQ6a4D6rLI4JeAUvmIjQ-sr9i8aqheBmkgZPsSxGujXy-a95QPUh3reAdJuyTcyceI_qIGsKGQKDYMt6w0twlCgjBlziCqKFz6X1b76ZugEAOYru_Fb0ESlSumNZHXP9QhC6ufmvZVzDjnWTNRZWY7cOwhgCYSc_5L0IdEySJdoyR-cgeo4EEy83rQIBfwdmqCY1P33n7oPPa-CB4q24UNSlTl6iztbYQTchILhDn4jrZTG5PQp4sJ5qcAqpUUTNyB-Wd_dafe3LdpNCTMcCUt01KGZF52nLDAHd-m-noOjxR8QhoDZkSVzRAKg3XnEKlPPNNvnuyErNkA3AQifFNpiXfhQPMlbxKH-grCvg6xvPAcLHs3tfZ2JxJ9uCcMDfLvuRv5atO7nC3LtHaTE8WoHyelkm1_CoG1XSD5omd2ahuk-ev0zE6hDGrSFRu3zJSf4spKPgAn-JK_hjR3eK-e-nf7jnTZNC79jDl7uvgl55dru_1jxUHLbj6IZO6-o_ZqIxIcY3q6tTh6UnxO8FyaTFMPxOI-eD8b5Jgu8oYoL556BomMgwQ4zlauLui_EjtfY3T90BsJFGtrep-Hf2suqSWwPWJL1oRG5fkHINXF4oVsDGEiaHpRdrUJM0S00tjinu3A5uahnK4cLln8uDEmuuEoOaYL0t85l1418azwXuAxiui48SQ99ESWcCAwFjAA1tYXN0ZXJfc2VjcmV0AEqY5Z4C7gCgErw6NoPqFWnv1hPza0eZ78Ef_H7nXiPB8AuTqLZDDk3chzjhyzeTjANDQ9ITN37GkogZO41eY4Nc-H__sSgvAcDDgwARYmlydGhkYXRlX2RhdGVpbnQASnbXhPkF2SyqXzhIZZVRlkfwSaCHpCiQZIdabXrMTeAW5bJhE6xszYCMq0EIaaXZ_9XbP61qtiJkbOz2n65Be6aIwhU55fcOj9RpAAl0aW1lc3RhbXAASsOw9hG1gUcCAUcalgdlDf0g6XXaAwNzEH8Id9YfY2L9NO9Mp_bRiC6xJ-iVsVt9YHFW26OWJKdp7pRmAWtgGLes2RNZbvPR69zgAARuYW1lAEp0DWphfK8tCbmpUZVU-LA6EIr9QrWSctDnn0UbhcWCLoYlWSN926YyeDnvxN7VzcCEGykmlMYKo-qoJKnrsD6L1A_N7s4PDDwEJgQASppRnLTXCuMfbKYOsuTZoLu1SgM0cmccRSYXEes0VkZ4mPAGtOu53VhCecQiLsG9nQAFyGQAm7WDFY5FSnZvsiZLtH3zwY-jtlPs",
-        "ge": [
+        "encoding": "auto",
+        "index": 0,
+        "mapping": {
+          "revealedAttributes": {
+            "0_degree_uuid": "degree",
+            "0_date_uuid": "date"
+          },
+          "unrevealedAttributes": {
+            "0_name_uuid": "name"
+          },
+          "requestedPredicates": {
+            "0_birthdate_dateint_GE_uuid": {
+              "index": 0,
+              "attr_name": "birthdate_dateint",
+              "p_type": "<=",
+              "value": 20041012
+            }
+          }
+        },
+        "eqProof": "AAEAzHDfd7FQqeO8P3blJyCIJxiBXrxnWEVdMj6X0JSOPOu_GYQt3gVdbBt7JMo9ZKCIFrat6KVfMMno_jD9i_YRLydG8WegmDI70bvQz4un2TliF7hNo3nTDX_TA1FEuk53zIolm2Vnf3L1HpSeIAFbUjis-2jnQ1xBqbM315Zl6Ve-AKipHlfJ1aqYN5RVOzL-Y8bXmSbsJ0CuFXqCbK9FCPYz8wBKIyRiq7S6QM9yy8RZcQ6a4D6rLI4JeAUvmIjQ-sr9i8aqheBmkgZPsSxGujXy-a95QPUh3reAdJuyTcyceI_qIGsKGQKDYMt6w0twlCgjBlziCqKFz6X1b76ZugEAOYru_Fb0ESlSumNZHXP9QhC6ufmvZVzDjnWTNRZWY7cOwhgCYSc_5L0IdEySJdoyR-cgeo4EEy83rQIBfwdmqCY1P33n7oPPa-CB4q24UNSlTl6iztbYQTchILhDn4jrZTG5PQp4sJ5qcAqpUUTNyB-Wd_dafe3LdpNCTMcCUt01KGZF52nLDAHd-m-noOjxR8QhoDZkSVzRAKg3XnEKlPPNNvnuyErNkA3AQifFNpiXfhQPMlbxKH-grCvg6xvPAcLHs3tfZ2JxJ9uCcMDfLvuRv5atO7nC3LtHaTE8WoHyelkm1_CoG1XSD5omd2ahuk-ev0zE6hDGrSFRu3zJSf4spKPgAn-JK_hjR3eK-e-nf7jnTZNC79jDl7uvgl55dru_1jxUHLbj6IZO6-o_ZqIxIcY3q6tTh6UnxO8FyaTFMPxOI-eD8b5Jgu8oYoL556BomMgwQ4zlauLui_EjtfY3T90BsJFGtrep-Hf2suqSWwPWJL1oRG5fkHINXF4oVsDGEiaHpRdrUJM0S00tjinu3A5uahnK4cLln8uDEmuuEoOaYL0t85l1418azwXuAxiui48SQ99ESWcCAwFjAA1tYXN0ZXJfc2VjcmV0AEqY5Z4C7gCgErw6NoPqFWnv1hPza0eZ78Ef_H7nXiPB8AuTqLZDDk3chzjhyzeTjANDQ9ITN37GkogZO41eY4Nc-H__sSgvAcDDgwARYmlydGhkYXRlX2RhdGVpbnQASnbXhPkF2SyqXzhIZZVRlkfwSaCHpCiQZIdabXrMTeAW5bJhE6xszYCMq0EIaaXZ_9XbP61qtiJkbOz2n65Be6aIwhU55fcOj9RpAAl0aW1lc3RhbXAASsOw9hG1gUcCAUcalgdlDf0g6XXaAwNzEH8Id9YfY2L9NO9Mp_bRiC6xJ-iVsVt9YHFW26OWJKdp7pRmAWtgGLes2RNZbvPR69zgAARuYW1lAEp0DWphfK8tCbmpUZVU-LA6EIr9QrWSctDnn0UbhcWCLoYlWSN926YyeDnvxN7VzcCEGykmlMYKo-qoJKnrsD6L1A_N7s4PDDwEJgQASppRnLTXCuMfbKYOsuTZoLu1SgM0cmccRSYXEes0VkZ4mPAGtOu53VhCecQiLsG9nQAFyGQAm7WDFY5FSnZvsiZLtH3zwY-jtlPs",
+        "geProof": [
           "AAEwAEqNkLa-DWiPyz7yvsgIkUe_Z8Bg3lmrrbOwz2GsJrFoFKmFxFnwHa7K8JQewQq_E2zXhrZdzFMAXehG8rMlVaQlHXfajCg8fCe0AgBKbwJGfQCMSFiRztMJ4GTQ0X1H986sM6DVsMrj_uf18-t7Q7myW6A-AgzsYe0CV0Vua8OVfAuZwLzjm9F4-vy9fFm1Z-NcCi5snE0ASo40NwPcy2YpXLjV9tka5575_WB_gVjAwXv083dkJ7UfE2xhp-2c_3A9XX5PnQ-f-2osLFpY4hVmjzPwHvaEvL5SSvhuaaKPVvHmAErcW58H4GRjNwnecEVoBkxYj-FX3NBg7jQGMhnpnV10E_r7s_P8x-CehHOPB9JnrPk1oWpwhU-AEtK8QDzSSo_59cfL3fZP6j5WAAEF3AEqAv_r5rpeRgCMIoTR8cVc1SWcr0IdPjV15wXNlswLS7t08iIIT120q2ca5m0fpjJ41zHHbJN0z5gEn1oRXr4QmSzz8SY_vusw82VifrYcE3Agsvl4QAbQaXcKiiaqXm3Bj81ALV0O5ufg7cjPpViJcdmG99DcBQhoRNri04oYez7VF9CmyJNIb3n2si00Vka_vLzd4rkhbfIlLTxSwCdtd-ZdoQb7t5gZ2iZN861pL8oXtC0T1H3GqW8vI00m4c4aoYOqZ6yR10kljl1Rv7AKjgEvz7hxKqtUCnBtiFaVdvWbFIqpjXH7Cvz8UNXYsAvBXo3-MwB2iDqnanIFOEx6RSxWBaWj1WdezzWSoOyiK9n1q71BGUrWb87EaJWb_un2jWBQ-ZwSu4Q0lAEqAvo-taHIs_DjqgivmcPwsLza0w7dOsU4Ezs8BIa7OYqZtaBCJoI1376rYImztFRGUQW2auGTJAKf95_pAut-iOTIKufwrOhH6BxDxVtlaIvIdD30ZzJNMgM93Xv4N5MTEx4d24LYt0VYzSeLcjHlGe9ACs3ScQOHx5T_1WV063XmIGWFpox4hcuSqNBoDzt80U1ZPFFaygeyZFV4SYJrQyOJX2fZqQnYCTyjabYxFxP4aey13PGyvymjFpwOzmJE9J95EyiCWNXKQEuKrhq1z4GNkyTP-QVB6w-O86G8Dhtwv4WYOSxiOCddJ_iMDz_Quv9cmTePUsHIj2N2PKhBwlGT6WgM_tv1N98n4VnLLSPyYAaAJ1_iQ2eaL-I0GLxOSK-AE-eJmOWPmgEqA-Vijc2RKVKA9UZcHX_iGZq7gjjQDVl6GI-tPhqjV1D8tpHEWGa7cRCnnLONOEQPC7OrW-TamQTiOuJDkSuLQGKGaX46Y3KnfYPmPDNX_dlvBAZGa91Ep_SEgAF_lJJzw8aZF9DUf-VrDQj5Ceha09-CS1mIYcZdtw-1m6SCDRjpi1tZmFyHWwNNHHabmINuaa6sZ5KiO0rJvVm5qyq9n74BzaWo6vvk2dt0OrsdBrpYeXWA8SDqPk7aJn5xw0sHZBAzy39slMoe8SvF5bh9SOmREV2ewX1WbB5_pvMGh-wJNma7Il1YJPaSpsj0oRQwdBZmr-qizzTGq4g7amIifg9AQjEW8Z-iuUQRq0ojh0ah8l5VW2FaN53RT_dcfA05_krdFyQIq5i1zQEqAXRPTbBAFoqUCGCVrPHskEXrh_BBFx0868AkcgzbBQ7HgGvVYIM35GnlatRMfk9trvJ5tbGpqmfucibCsm--9giXXXznb3E8rmlcCA_mO08zDLRnjxzVP6RAcGJa87qAoIkP7OxGMqkTxXqbi6ui0Gf4T0wsWiJeZEaHxXuMnePQPve23ChCokQXa2QEM418sRPkO7EB51Xt2QrqZ_5ZErz7OFOL9mPRn49o5YoHj3Ip25uhXLpF8MOs0rxkV19poYgBOUH2TnUBTvuUl4-UnjKg2JompC-owr1DoRDPb2CCPF20xt6cUfc2W2uJ8QNEXi2enGfhddRiCp5mPujE6TKfaAl2PgdggqM-aXQAPgXOgDfl7JBt8oQv4foHRn9Zfh3eIKgnmbqSnQEqAnrq0hd40Mmj02Bmm6Azk1LTA8h7i2B2swyJK30J-tgXlTc2vPztE0cwI8zEPlMIFtDZOw1p7CXQwdw7nrnJA3vakAVMQzKQkTaZRJBNw7EOge0Rj-7d6rlbH88dEmKZVgsVe9dU_PXs8Af1u4FObS05IC2ITIegMue7fA-dsogV0L4VGSuy8BIzCaXXV3_sze5RES-cs0O5gfDF7wNSnGS4W0pdpYebkj8b5fKCarni3tUNfoWt_d_-_5v1Ubswozw2oMcqn8O4Z_IiYPoLm6rVLysI4v5WslQg03X7U-RiYyBfCwg_C8saiI6mLfoNiQX7VC4wS_W4F5O6SkQzK4W2mlyeWY3BCF4AoRsixDCVl1jn8rqVyxme0vU3-03ziL-tjrOamadjagIASnbXhPkF2SyqXzhIZZVRlkfwSaCHpCiQZIdabXrMTeAW5bJhE6xszYCMq0EIaaXZ_9XbP61qtiJkbOz2n65Be6aIwhU55fcOj9RpAwFdBt3RdJN10IXajQ9Z4wsFj3es-30l-SIjrdK2zf-2x9LIs_gWm4MSKA-o5y4-lMPv0xVqW9YuZzLEg-tFqugOnyLvrMW3ANERcWEqZRpettD8vl1tJAMN3EdwoZiOjSmTESVXsas-N9Qk0RYyjQXnbx1s3S1ZqZxr9fVrfw0h9OydaxvXY6zzR2eIOWU56hxv2MmaJkgnPsfbwMIQnRVWpvwaKDtVIqfrUpTANIqdEsKWXQtt0txrBEgBCBUtkufJa5eiwENTMLIyHLaN2e5ohYMWwY0l8tO8i_BEv_M0-Q5LtQf_-nfvaAKq5UdkYnxMScK8mk7XPlaUtVyWqW-BDH33UVSUEZRaKtN5wmQ9SAoN6LnKC-z4jl-RpC_-wVLP1uHVq9TSips3Pb4mv1vY7JkM1SSra-RItQWoPhV_aBkVUG4klqGpjfp4LNuF8uRJ0clwWxUMrSc1CdoBkgQFDwEBAjPOuLNhx-_RxxoLeqSkOViuVJqSuBXDpsrLEGg6wrdNNwJ3VC1nXaCBHELkl4rKOjbbCtMpRFrX0CnWCNVfvaDLntzgDFzPxEv3r-aB1dSTGqnJxcqNqYg8r7BIFwqrNvC99bSfGa7CnYrYhRUbKteE8tdTkWnnENyEYuCd-1Ih8zAAjdFuheBbS3CAVBhHVorldMuTw1tlII7piLq729j3EtGCFg9Rgs9bXavbFBTD2TgA0AwenNUi6DqHAvprymSjTY0de2SclSBAHRWqQA0QiuvYxiwLlvjLUtWLgUpJ4vqedx-4xTueubIIteXOSU08hBP_hwJ1AVCMmUF6mDUBAQEcifNZRAT1pjXIRXsV6lgcUTfYRz4t1ikQvolBTi5tnb4ePS5O3k4gqCdbsUp-3tokLii5fP-daqiIAdxcX1cHuzFQtjAw9tcVb_hq4jcZo3KP6nl-S4ZvtrLreM8A8jY5KR13RCYQtBEqJl11GUkrIsXQr8BYEoOkDL1VlatDvmhvUmAuFDa4klyps0kQrSdiYGExCBVPazxRMTUpmXXteUkUcaKfGK9Cdva6t5afA1_150NS1DGTb2uJASg8N07tIwm8YRj982Zkjk_EIMO_9-s4Xe4I9QNtcpbvQ_CswFGEJwyttkX_1amEshCYUq7YcNm4qCTsRd_WW4DLGTARAQECs6oxTPWi-VnDr4p9itsbqaMHOdd9iW726QeXaBgnbJqHWKV9eiCQEJNC24zkUZbXlB4CC6kkJ0pz3bWE7RT9Hyz_D73Pk9qiJk9-u-JjNCGlaAuGwrJh7XgSua-xOGYiLNSHnPHk-6comSJNdeU2UJ5RqKMpnvyAttHO0m9bFfxZ6smmjJdpkP3dkhJyLLuRu13fHFcTYOSO_ZWYXMCdmCfPc3CbU5mCj0VSbbAj6w_ZF6EyZEisS3JOu6VATJTWczBTrOlGYUKjouj14JiOI1EKAqAT7yCzNQEihmDd-8SuspeqilIHfSBQOrWcx0qybbImERULs6Ox8UlkdWKSHAEBAV_B08cenSBsIbIFVwRPPlSGlSbOwcfg6nUTy6XAsA__m43JX9QBagzSMHrK4-jfzNai75d4KqX1o_CD8DZiAZeehMhp3TmnMhso4-rCWS0rGIBMeJYjrcoSrErgWo8_zHYuNjWMIIL1PJSvtvz-ggo56-_VBeIgHxfoNui4cOX_e_EfVU4uZLhTtHwXC6rXM48bROp8cqHUs0WfLO3nW6ZmPCZjV80ijr_U0NyQBF_sOLs_hyqcM1VpSlGN44dEndH1-Jx_3BbjyX1YuvkgceaHZaX5Jnbc8SMbzVVTNDFWQ0fdd7YrZyBJc_7-32bdGvFYtVwtZhEHS-_wbGqHpEQBAQEnR0BBKTFzJRL9sfQTOkGPhs42bUbunOmr3_n6mQ1R0mnNicmCDuDFQch-c2vUJ05VLlxA_1GE42bw4KTL9x87N8PG-Q1tEcRsSaMAIf6jS5B8Mb1n7oh9DyYDYHUfOeSwVBz4PA2tKSayPdMgR2TVWNh3xVFPh5AkZhwHEAiE5NH6dY2m4OwdDSyOVBzIISOmwgBE7w_W02xBZ37Gjc9BJxua-vvmSXUi0w9OnYgE9VuikLwF3hAnAObiZsy9Q36axkvBGN8EYmDpD2HId_afPfhwXxv3z7XgWsgxvhZ1fFxi8bOdbob3DvdXqN4uIFwn65o8ENG_UHSGcNuwZYLw"
         ]
       }

--- a/W3COutput/W3C-VP-ComplexProof.json
+++ b/W3COutput/W3C-VP-ComplexProof.json
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://anoncreds.example/spec/v1"
+    "https://raw.githubusercontent.com/andrewwhitehead/anoncreds-w3c-mapping/main/schema.json"
   ],
   "type": [
     "VerifiablePresentation",
@@ -11,87 +11,107 @@
     {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://anoncreds.example/spec/v1"
+        "https://raw.githubusercontent.com/andrewwhitehead/anoncreds-w3c-mapping/main/schema.json"
       ],
       "type": [
         "VerifiableCredential",
-        "AnonCredsCredential"
+        "AnonCredsPresentation"
       ],
       "issuer": "did:sov:CsQY9MGeD3CQP4EyuVFo5m",
-      "issuanceDate": "2022-10-28T21:33:36Z",
+      "issuanceDate": "2022-11-08T19:24:11Z",
       "credentialSchema": {
         "type": "AnonCredsDefinition",
-        "schema": "CsQY9MGeD3CQP4EyuVFo5m:2:MYCO Biomarker:0.0.3",
+        "schema": "CsQY9MGeD3CQP4EyuVFo5m:2:MYCO%20Biomarker:0.0.3",
         "definition": "CsQY9MGeD3CQP4EyuVFo5m:3:CL:14951:MYCO_Biomarker"
       },
       "credentialSubject": {
-        "researcher_share": "bf712cb328a92862b57f0dc806dec12a",
-        "unit": "\u03bcM",
-        "concentration": "10",
-        "name": "Iron",
-        "range": "9.00-30.0",
-        "collected_on": "2020-07-05",
-        "biomarker_id": "c9ace7dc-0485-4f3f-b466-16a27a80acf1"
+        "attribute": {
+          "researcher_share": {
+            "value": "bf712cb328a92862b57f0dc806dec12a"
+          },
+          "unit": {
+            "value": "\u03bcM"
+          },
+          "concentration": {
+            "value": "10"
+          },
+          "name": {
+            "value": "Iron"
+          },
+          "range": {
+            "value": "9.00-30.0"
+          },
+          "collected_on": {
+            "value": "2020-07-05"
+          },
+          "biomarker_id": {
+            "value": "c9ace7dc-0485-4f3f-b466-16a27a80acf1"
+          }
+        }
       },
       "proof": {
-        "type": "AnonCredsPresentationSubproof2022",
-        "encoding": "auto",
-        "index": 0,
-        "mapping": {
-          "revealedAttributes": {
-            "biomarker_attrs_0": [
-              "researcher_share",
-              "unit",
-              "concentration",
-              "name",
-              "range",
-              "collected_on",
-              "biomarker_id"
-            ]
-          }
-        },
-        "primary": {
-          "eq": "AAEBAnr2QlWJXV6EkhT-h2BNW5hYmX0VwitrytT6GRX49yVS14LyDxDU1-3CzkmvSTTZ5m3WYGUf-gm8fqJEntxgTfyum9bAzMfihaGQPzODGxKl75CRTEcOYHdHQ-3uSx21faiPbH4vrYkXcxoDUKw9oc-NYuRAaY-mes2EKAv7PXmmbAIsTWwxrfq86ea8exoxfyd9HY96yF_LeIwigowg1SHC_qdpk1jlbPk8XEC3vK77WajulVpEIEj3h_HLANIkV4-D0gJ4CSKd-cLGZdiGrXJy_OuOVJioRS0IpWw3Ohb_JJ8NKLhkSUKpjKZRYG4paUQG7lNNAMc9QPHWpCMR1QEBADmfDHTZkqi1GzjEfeVjSu63oycEdKbQamEDPM11dg_02be6cUnKOkVQ3B0JgMzWN1P-8lUkfM0syosCAX8OGuhT8_ZV1o7TKkp4vDaX43upHmYFQf0jC-XHs12W2JEQ_oMbV_tkXwv0aPUPlTLBPlB24-jD6tkawmmBDTA0ePWp3T_RCZ21lJYsDB_oiQaucplMHnxomaJNTDg7TudroYRwh3TV3NOY_gq7i25O4KqZDIIllVuVACSUIP2Yn8OmId05nsYNjEWA8gqXeDe16D7AYO4KKCrUApvahFFsNCqSr9UOEXIILN0IRTEh1KtYHF2GcrBFM6mazQc2Yey7JBVxEwGN5Lt3jGQzbcWns1U3By_VTKQt5pi0eoLuwxQr8Ma8F0q7m17AMWrQ7oyvC5NPIbkmJUldLWZ-UbEs5bWGH0I3aWUp2auXuQKGHc0q4293nQeRcVRhyuhO2qVPkfoLJJl9LZO8gpVSaGXrcbj-1i3i8dHk8euyss3Pyv-HXmgRRVoBeswB-_Jx_lJRdq90g95RdUgpHyULPsX88hUZCDSBAx8wjxphKMKjPgOSuYXP3dM2snmNy0018wMAtQANbWFzdGVyX3NlY3JldABKNpSwp1ZNhmvC5c39st9DdgBJKLrQhsr_mOhZtbZ6NVf4dwgUrcpd6WRYDW3zV-AXn1TOUh92UBgraM_1CiTKVT4tx6v38ErLatcADGNsaWVudF9zaGFyZQBKQt1xHKRmqKNS-wBRJsGlYYtLLWkn-nIa1iWij2vX-TllDxNHemndcw_2FwymDN3A0tYy-2PSORbPdFQOsRp-0sPYdyiYkEoPk8wEAErMaZdyhxg_OfqQPldHiOgS1Rd5bHg5gbgh0IpGutVzSxBRuaqYufBAz-3rkh9SngWzEFy0UhJ-bIIdWFKVWxjU3ePxv_7HoY5pUw"
+        "type": "AnonCredsPresentationProof2022",
+        "credential": {
+          "encoding": "auto",
+          "index": 0,
+          "mapping": {
+            "revealedAttributes": {
+              "biomarker_attrs_0": [
+                "researcher_share",
+                "unit",
+                "concentration",
+                "name",
+                "range",
+                "collected_on",
+                "biomarker_id"
+              ]
+            }
+          },
+          "eqProof": "AAEBAnr2QlWJXV6EkhT-h2BNW5hYmX0VwitrytT6GRX49yVS14LyDxDU1-3CzkmvSTTZ5m3WYGUf-gm8fqJEntxgTfyum9bAzMfihaGQPzODGxKl75CRTEcOYHdHQ-3uSx21faiPbH4vrYkXcxoDUKw9oc-NYuRAaY-mes2EKAv7PXmmbAIsTWwxrfq86ea8exoxfyd9HY96yF_LeIwigowg1SHC_qdpk1jlbPk8XEC3vK77WajulVpEIEj3h_HLANIkV4-D0gJ4CSKd-cLGZdiGrXJy_OuOVJioRS0IpWw3Ohb_JJ8NKLhkSUKpjKZRYG4paUQG7lNNAMc9QPHWpCMR1QEBADmfDHTZkqi1GzjEfeVjSu63oycEdKbQamEDPM11dg_02be6cUnKOkVQ3B0JgMzWN1P-8lUkfM0syosCAX8OGuhT8_ZV1o7TKkp4vDaX43upHmYFQf0jC-XHs12W2JEQ_oMbV_tkXwv0aPUPlTLBPlB24-jD6tkawmmBDTA0ePWp3T_RCZ21lJYsDB_oiQaucplMHnxomaJNTDg7TudroYRwh3TV3NOY_gq7i25O4KqZDIIllVuVACSUIP2Yn8OmId05nsYNjEWA8gqXeDe16D7AYO4KKCrUApvahFFsNCqSr9UOEXIILN0IRTEh1KtYHF2GcrBFM6mazQc2Yey7JBVxEwGN5Lt3jGQzbcWns1U3By_VTKQt5pi0eoLuwxQr8Ma8F0q7m17AMWrQ7oyvC5NPIbkmJUldLWZ-UbEs5bWGH0I3aWUp2auXuQKGHc0q4293nQeRcVRhyuhO2qVPkfoLJJl9LZO8gpVSaGXrcbj-1i3i8dHk8euyss3Pyv-HXmgRRVoBeswB-_Jx_lJRdq90g95RdUgpHyULPsX88hUZCDSBAx8wjxphKMKjPgOSuYXP3dM2snmNy0018wMAtQANbWFzdGVyX3NlY3JldABKNpSwp1ZNhmvC5c39st9DdgBJKLrQhsr_mOhZtbZ6NVf4dwgUrcpd6WRYDW3zV-AXn1TOUh92UBgraM_1CiTKVT4tx6v38ErLatcADGNsaWVudF9zaGFyZQBKQt1xHKRmqKNS-wBRJsGlYYtLLWkn-nIa1iWij2vX-TllDxNHemndcw_2FwymDN3A0tYy-2PSORbPdFQOsRp-0sPYdyiYkEoPk8wEAErMaZdyhxg_OfqQPldHiOgS1Rd5bHg5gbgh0IpGutVzSxBRuaqYufBAz-3rkh9SngWzEFy0UhJ-bIIdWFKVWxjU3ePxv_7HoY5pUw"
         }
       }
     },
     {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://anoncreds.example/spec/v1"
+        "https://raw.githubusercontent.com/andrewwhitehead/anoncreds-w3c-mapping/main/schema.json"
       ],
       "type": [
         "VerifiableCredential",
-        "AnonCredsCredential"
+        "AnonCredsPresentation"
       ],
       "issuer": "did:sov:TUku9MDGa7QALbAJX4oAww",
-      "issuanceDate": "2022-10-28T21:33:36Z",
+      "issuanceDate": "2022-11-08T19:24:11Z",
       "credentialSchema": {
         "type": "AnonCredsDefinition",
-        "schema": "FbozHyf7j5q7TDn2s8MXZN:2:MYCO Consent Enablement:0.1.0",
+        "schema": "FbozHyf7j5q7TDn2s8MXZN:2:MYCO%20Consent%20Enablement:0.1.0",
         "definition": "TUku9MDGa7QALbAJX4oAww:3:CL:531757:MYCO_Consent_Enablement"
       },
       "credentialSubject": {
-        "jti_unique_identifier": "205b1ea0-7848-48d4-b52b-339122d84f62"
+        "attribute": {
+          "jti_unique_identifier": {
+            "value": "205b1ea0-7848-48d4-b52b-339122d84f62"
+          }
+        }
       },
       "proof": {
-        "type": "AnonCredsPresentationSubproof2022",
-        "encoding": "auto",
-        "index": 1,
-        "mapping": {
-          "revealedAttributes": {
-            "consent_attrs": "jti_unique_identifier"
-          }
-        },
-        "primary": {
-          "eq": "AAEBAaJ19hG1ctE6MUCRF4ZxAFUfk5LImKIcQkKpT5hRNYLBaYWiJbgKRCV3H1PG9d53Oe4nzugeCCg26tNW6zUe1TOIXR1b70NIOXm5T4-AXzw_Qpxa4NnLDYPuEWxcXg3kNn29Ut0ozJEviwGx9FWW878PoR09SH2OzaXGvpAWZ8ZTFlt2MUA5d6_9QEV-jjK52aQQgC7J2Kf1qOUOcbtWYdd5j6sotyQyRPp6-_LzUCbstkS-SqzjV-oBAFq83TBcc0YtBvH91BngNJmpwmydvogcLzecWtd9l06vWWRN_Ve9Mt6edA5ofyQA2uDtCwg06ZqsBBq2BAzKe6VxmF-agSABADk3gQhGDchPC0eanv6DNVaQ3dlmhD6dljbiBxpxnAGmfEvcy7UQJgkFWPpU7kCHFZbRLtpHZrfnIm0CAX8CdS36H3jtUA_JFQRnW1Uc2XuWAjh3QYuQ8M09VMuhja6AqyARhpt_p-vHSraSap1c91H7WBwxbf5on13mX8jfLhy4bBcBE0eH94k2tq6gQeSzn2csCD8I9kyGojZkvADdVVBSnAOwFtE6ocMIGhgPF2L4r1X324DCMjr1HcAVUy79e0msgOPGpXkSsdHDOAcK7RA3SXg4choe3JAce-EGOB2tMyo1TL1jQckGKmcp4NgqC9JClpYaqvGscwijmwz4a1CePtbhcHqtC3AP0n8mYzsZNaDqo6HSXn-jqpxN3ZN-4ID3FE3Y-eGkikf5K7YMbEMeD-RKhKDeCiW5pUlHafOlw-yljmusm7mCsVJkIIB9F7N7M51zKJFbvSq1RQfejlQcQKSstwMNaVpieDR4S_5fNXxDavgLfJwldZUFHk8Xfgb6ib4H4qfSMTeSmO_GlV6GlC19sZcW_mDeOlg8Ai2M4x8iy_3xgPZ5xYq3n4KcRXM69zWicLmluFCA6gMEfAAVaWF0X2NvbnNlbnRfdGltZXN0YW1wAEp9EuGn8-es9xA-0M13816a39BNhz5OiQBoowNKe-dTh5Yw7K7rRa_YSjBHWEVY6q_KyBzqL7Io1BEppOIswkBfWhVYgGEtPepkdwANbWFzdGVyX3NlY3JldABKNpSwp1ZNhmvC5c39st9DdgBJKLrQhsr_mOhZtbZ6NVf4dwgUrcpd6WRYDW3zV-AXn1TOUh92UBgraM_1CiTKVT4tx6v38ErLatcAD2RhdGFfY29udHJvbGxlcgBK_dAJ27qv3UR8oabLOYMx2hXSh3ey4E8ar07JXSfykkVCc1rgm9qH6q0PDSieQOy2L7fz6Hpxiv7RPo1hRDMovmtUdiFjxgoWK9UABm5vdGljZQBKLBLtaMjd6A24-5_qwEimjqnzTEG8Y7X4Q2_8L31cix_8g88FzTQXDn5gftifpWiFGwMLTI9BMaQNl9RAOpUj31i6c6-3pnovyIUACXNlbnNpdGl2ZQBK1gxlDy5a3WVkfR9J7CsFORShzfUbTPLpL76jVrnQYN1DMcEfOVi8LPXKVUgPUmwbMo0m2sxQ63G8xE49hBiofzXX_HDhuAgKe-sACHNlcnZpY2VzAErqtY3y7uBr9HSOWcEwlMcFM8Gi-XN8QvS5kuPEyyhkKOGJ4CKDYrc31Ch_80Ly5LubGLbL38-rd0XB8o2oxPAgjO83HgdIhFZ_hQAWc3ViX3N1YmplY3RfaWRlbnRpZmllcgBKuVtqPAxNbTywD65SJoHo-_DLMAKxP3kKxrvpmFPCTDDSa64J3ox99v88YkJX-Zy2SsQ53crmp1dkSOdBnxmm-731ylVYHZ3p3O0AGG1vY19tZXRob2Rfb2ZfY29sbGVjdGlvbgBKnlpT2EwTHTQ1Ab-L42u17GnM9MnX7tBRAGOgKCJDnup8u-96Y_kJQtgkzogIxnvc7K16fUequwTQ72C1xAMI7SPm4I-Lqakyy4kAHGp1cmlzZGljdGlvbl9kYXRhX3Byb2Nlc3NpbmcASvn__VuPw8WFAYjOmBl_EN6Cu_S8tiKZTBmBnhR6cm5Frn353ow7tbzQX6P53LnMzs8fAynhiSQT5ioRBHRtR5NAIsG44iVC9iUmABtpc3NfaW50ZXJuZXRfcHJvY2Vzc2luZ191cmkASmz9H8nALYor0NYdLcMqrUycFpNiS3k1tRNYQTr_0thtTY9m_MhFNYwWp8e5uXtqVem_qlKW8wL6fkwC9tEje_mJPPsPc4ztXKbEAB12ZXJzaW9uX2NvbnNlbnRfc3BlY2lmaWNhdGlvbgBKeyGh1pJ-ux8al2eENRJ0PgbmT2TVy2ab9_pwMp4NVCED-CQHFh3Wd7T7Sy64Vl35UrXXzsWm_Q08LwAeeOdGoZY_tQH_jKIZXYEACnBvbGljeV91cmwASsFXPFTDatFgiveyss9eGefRI3czecVaZRklTaq_Hd7kP4AQvrE3q450LvuG8XtqtyxiDIXZSPfJ9yxRwzri2Dt57BeK1L8tJqYxBABKZs2MpyOyxshiglchyhYfh5jD7fx6pYajVitQ3FUrF8BqvQGJOBfZYPB19O62RjgOBPMiCk4W1HPqK2QpBgPY4hzwyutfHssNn5k"
+        "type": "AnonCredsPresentationProof2022",
+        "credential": {
+          "encoding": "auto",
+          "index": 1,
+          "mapping": {
+            "revealedAttributes": {
+              "consent_attrs": "jti_unique_identifier"
+            }
+          },
+          "eqProof": "AAEBAaJ19hG1ctE6MUCRF4ZxAFUfk5LImKIcQkKpT5hRNYLBaYWiJbgKRCV3H1PG9d53Oe4nzugeCCg26tNW6zUe1TOIXR1b70NIOXm5T4-AXzw_Qpxa4NnLDYPuEWxcXg3kNn29Ut0ozJEviwGx9FWW878PoR09SH2OzaXGvpAWZ8ZTFlt2MUA5d6_9QEV-jjK52aQQgC7J2Kf1qOUOcbtWYdd5j6sotyQyRPp6-_LzUCbstkS-SqzjV-oBAFq83TBcc0YtBvH91BngNJmpwmydvogcLzecWtd9l06vWWRN_Ve9Mt6edA5ofyQA2uDtCwg06ZqsBBq2BAzKe6VxmF-agSABADk3gQhGDchPC0eanv6DNVaQ3dlmhD6dljbiBxpxnAGmfEvcy7UQJgkFWPpU7kCHFZbRLtpHZrfnIm0CAX8CdS36H3jtUA_JFQRnW1Uc2XuWAjh3QYuQ8M09VMuhja6AqyARhpt_p-vHSraSap1c91H7WBwxbf5on13mX8jfLhy4bBcBE0eH94k2tq6gQeSzn2csCD8I9kyGojZkvADdVVBSnAOwFtE6ocMIGhgPF2L4r1X324DCMjr1HcAVUy79e0msgOPGpXkSsdHDOAcK7RA3SXg4choe3JAce-EGOB2tMyo1TL1jQckGKmcp4NgqC9JClpYaqvGscwijmwz4a1CePtbhcHqtC3AP0n8mYzsZNaDqo6HSXn-jqpxN3ZN-4ID3FE3Y-eGkikf5K7YMbEMeD-RKhKDeCiW5pUlHafOlw-yljmusm7mCsVJkIIB9F7N7M51zKJFbvSq1RQfejlQcQKSstwMNaVpieDR4S_5fNXxDavgLfJwldZUFHk8Xfgb6ib4H4qfSMTeSmO_GlV6GlC19sZcW_mDeOlg8Ai2M4x8iy_3xgPZ5xYq3n4KcRXM69zWicLmluFCA6gMEfAAVaWF0X2NvbnNlbnRfdGltZXN0YW1wAEp9EuGn8-es9xA-0M13816a39BNhz5OiQBoowNKe-dTh5Yw7K7rRa_YSjBHWEVY6q_KyBzqL7Io1BEppOIswkBfWhVYgGEtPepkdwANbWFzdGVyX3NlY3JldABKNpSwp1ZNhmvC5c39st9DdgBJKLrQhsr_mOhZtbZ6NVf4dwgUrcpd6WRYDW3zV-AXn1TOUh92UBgraM_1CiTKVT4tx6v38ErLatcAD2RhdGFfY29udHJvbGxlcgBK_dAJ27qv3UR8oabLOYMx2hXSh3ey4E8ar07JXSfykkVCc1rgm9qH6q0PDSieQOy2L7fz6Hpxiv7RPo1hRDMovmtUdiFjxgoWK9UABm5vdGljZQBKLBLtaMjd6A24-5_qwEimjqnzTEG8Y7X4Q2_8L31cix_8g88FzTQXDn5gftifpWiFGwMLTI9BMaQNl9RAOpUj31i6c6-3pnovyIUACXNlbnNpdGl2ZQBK1gxlDy5a3WVkfR9J7CsFORShzfUbTPLpL76jVrnQYN1DMcEfOVi8LPXKVUgPUmwbMo0m2sxQ63G8xE49hBiofzXX_HDhuAgKe-sACHNlcnZpY2VzAErqtY3y7uBr9HSOWcEwlMcFM8Gi-XN8QvS5kuPEyyhkKOGJ4CKDYrc31Ch_80Ly5LubGLbL38-rd0XB8o2oxPAgjO83HgdIhFZ_hQAWc3ViX3N1YmplY3RfaWRlbnRpZmllcgBKuVtqPAxNbTywD65SJoHo-_DLMAKxP3kKxrvpmFPCTDDSa64J3ox99v88YkJX-Zy2SsQ53crmp1dkSOdBnxmm-731ylVYHZ3p3O0AGG1vY19tZXRob2Rfb2ZfY29sbGVjdGlvbgBKnlpT2EwTHTQ1Ab-L42u17GnM9MnX7tBRAGOgKCJDnup8u-96Y_kJQtgkzogIxnvc7K16fUequwTQ72C1xAMI7SPm4I-Lqakyy4kAHGp1cmlzZGljdGlvbl9kYXRhX3Byb2Nlc3NpbmcASvn__VuPw8WFAYjOmBl_EN6Cu_S8tiKZTBmBnhR6cm5Frn353ow7tbzQX6P53LnMzs8fAynhiSQT5ioRBHRtR5NAIsG44iVC9iUmABtpc3NfaW50ZXJuZXRfcHJvY2Vzc2luZ191cmkASmz9H8nALYor0NYdLcMqrUycFpNiS3k1tRNYQTr_0thtTY9m_MhFNYwWp8e5uXtqVem_qlKW8wL6fkwC9tEje_mJPPsPc4ztXKbEAB12ZXJzaW9uX2NvbnNlbnRfc3BlY2lmaWNhdGlvbgBKeyGh1pJ-ux8al2eENRJ0PgbmT2TVy2ab9_pwMp4NVCED-CQHFh3Wd7T7Sy64Vl35UrXXzsWm_Q08LwAeeOdGoZY_tQH_jKIZXYEACnBvbGljeV91cmwASsFXPFTDatFgiveyss9eGefRI3czecVaZRklTaq_Hd7kP4AQvrE3q450LvuG8XtqtyxiDIXZSPfJ9yxRwzri2Dt57BeK1L8tJqYxBABKZs2MpyOyxshiglchyhYfh5jD7fx6pYajVitQ3FUrF8BqvQGJOBfZYPB19O62RjgOBPMiCk4W1HPqK2QpBgPY4hzwyutfHssNn5k"
         }
       }
     }
   ],
   "proof": {
-    "type": "AnonCredsAggregateProof2022",
+    "type": "AnonCredsPresentationProof2022",
     "nonce": "182453895158932070575246",
-    "data": "AAAgtMR4DrkY--ZVgKHmUANE04ET7TzUxZ0vZmVcNt4nCkwBABUACQJ69kJVIxHVAQAIAaJ19l-agSA"
+    "aggregated": "AAAgtMR4DrkY--ZVgKHmUANE04ET7TzUxZ0vZmVcNt4nCkwBABUACQJ69kJVIxHVAQAIAaJ19l-agSA"
   }
 }

--- a/W3COutput/W3C-VP-UnrevealedProof.json
+++ b/W3COutput/W3C-VP-UnrevealedProof.json
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://anoncreds.example/spec/v1"
+    "https://raw.githubusercontent.com/andrewwhitehead/anoncreds-w3c-mapping/main/schema.json"
   ],
   "type": [
     "VerifiablePresentation",
@@ -11,47 +11,53 @@
     {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://anoncreds.example/spec/v1"
+        "https://raw.githubusercontent.com/andrewwhitehead/anoncreds-w3c-mapping/main/schema.json"
       ],
       "type": [
         "VerifiableCredential",
-        "AnonCredsCredential"
+        "AnonCredsPresentation"
       ],
       "issuer": "did:sov:WzXgmpw6yvDdKaRcRnWxan",
-      "issuanceDate": "2022-10-28T21:33:36Z",
+      "issuanceDate": "2022-11-08T19:24:11Z",
       "credentialSchema": {
         "type": "AnonCredsDefinition",
-        "schema": "WzXgmpw6yvDdKaRcRnWxan:2:degree schema:75.57.82",
+        "schema": "WzXgmpw6yvDdKaRcRnWxan:2:degree%20schema:75.57.82",
         "definition": "WzXgmpw6yvDdKaRcRnWxan:3:CL:8:faber.agent.degree_schema"
       },
       "credentialSubject": {
-        "degree": "Maths",
-        "date": "2018-05-28"
+        "attribute": {
+          "degree": {
+            "value": "Maths"
+          },
+          "date": {
+            "value": "2018-05-28"
+          }
+        }
       },
       "proof": {
-        "type": "AnonCredsPresentationSubproof2022",
-        "encoding": "auto",
-        "index": 0,
-        "mapping": {
-          "revealedAttributes": {
-            "0_degree_uuid": "degree",
-            "0_date_uuid": "date"
-          },
-          "unrevealedAttributes": {
-            "0_name_uuid": "name"
-          },
-          "requestedPredicates": {
-            "0_birthdate_dateint_GE_uuid": {
-              "index": 0,
-              "attr_name": "birthdate_dateint",
-              "p_type": "<=",
-              "value": 20041012
+        "type": "AnonCredsPresentationProof2022",
+        "credential": {
+          "encoding": "auto",
+          "index": 0,
+          "mapping": {
+            "revealedAttributes": {
+              "0_degree_uuid": "degree",
+              "0_date_uuid": "date"
+            },
+            "unrevealedAttributes": {
+              "0_name_uuid": "name"
+            },
+            "requestedPredicates": {
+              "0_birthdate_dateint_GE_uuid": {
+                "index": 0,
+                "attr_name": "birthdate_dateint",
+                "p_type": "<=",
+                "value": 20041012
+              }
             }
-          }
-        },
-        "primary": {
-          "eq": "AAEAzHDfd7FQqeO8P3blJyCIJxiBXrxnWEVdMj6X0JSOPOu_GYQt3gVdbBt7JMo9ZKCIFrat6KVfMMno_jD9i_YRLydG8WegmDI70bvQz4un2TliF7hNo3nTDX_TA1FEuk53zIolm2Vnf3L1HpSeIAFbUjis-2jnQ1xBqbM315Zl6Ve-AKipHlfJ1aqYN5RVOzL-Y8bXmSbsJ0CuFXqCbK9FCPYz8wBKIyRiq7S6QM9yy8RZcQ6a4D6rLI4JeAUvmIjQ-sr9i8aqheBmkgZPsSxGujXy-a95QPUh3reAdJuyTcyceI_qIGsKGQKDYMt6w0twlCgjBlziCqKFz6X1b76ZugEAOYru_Fb0ESlSumNZHXP9QhC6ufmvZVzDjnWTNRZWY7cOwhgCYSc_5L0IdEySJdoyR-cgeo4EEy83rQIBfwdmqCY1P33n7oPPa-CB4q24UNSlTl6iztbYQTchILhDn4jrZTG5PQp4sJ5qcAqpUUTNyB-Wd_dafe3LdpNCTMcCUt01KGZF52nLDAHd-m-noOjxR8QhoDZkSVzRAKg3XnEKlPPNNvnuyErNkA3AQifFNpiXfhQPMlbxKH-grCvg6xvPAcLHs3tfZ2JxJ9uCcMDfLvuRv5atO7nC3LtHaTE8WoHyelkm1_CoG1XSD5omd2ahuk-ev0zE6hDGrSFRu3zJSf4spKPgAn-JK_hjR3eK-e-nf7jnTZNC79jDl7uvgl55dru_1jxUHLbj6IZO6-o_ZqIxIcY3q6tTh6UnxO8FyaTFMPxOI-eD8b5Jgu8oYoL556BomMgwQ4zlauLui_EjtfY3T90BsJFGtrep-Hf2suqSWwPWJL1oRG5fkHINXF4oVsDGEiaHpRdrUJM0S00tjinu3A5uahnK4cLln8uDEmuuEoOaYL0t85l1418azwXuAxiui48SQ99ESWcCAwFjAA1tYXN0ZXJfc2VjcmV0AEqY5Z4C7gCgErw6NoPqFWnv1hPza0eZ78Ef_H7nXiPB8AuTqLZDDk3chzjhyzeTjANDQ9ITN37GkogZO41eY4Nc-H__sSgvAcDDgwARYmlydGhkYXRlX2RhdGVpbnQASnbXhPkF2SyqXzhIZZVRlkfwSaCHpCiQZIdabXrMTeAW5bJhE6xszYCMq0EIaaXZ_9XbP61qtiJkbOz2n65Be6aIwhU55fcOj9RpAAl0aW1lc3RhbXAASsOw9hG1gUcCAUcalgdlDf0g6XXaAwNzEH8Id9YfY2L9NO9Mp_bRiC6xJ-iVsVt9YHFW26OWJKdp7pRmAWtgGLes2RNZbvPR69zgAARuYW1lAEp0DWphfK8tCbmpUZVU-LA6EIr9QrWSctDnn0UbhcWCLoYlWSN926YyeDnvxN7VzcCEGykmlMYKo-qoJKnrsD6L1A_N7s4PDDwEJgQASppRnLTXCuMfbKYOsuTZoLu1SgM0cmccRSYXEes0VkZ4mPAGtOu53VhCecQiLsG9nQAFyGQAm7WDFY5FSnZvsiZLtH3zwY-jtlPs",
-          "ge": [
+          },
+          "eqProof": "AAEAzHDfd7FQqeO8P3blJyCIJxiBXrxnWEVdMj6X0JSOPOu_GYQt3gVdbBt7JMo9ZKCIFrat6KVfMMno_jD9i_YRLydG8WegmDI70bvQz4un2TliF7hNo3nTDX_TA1FEuk53zIolm2Vnf3L1HpSeIAFbUjis-2jnQ1xBqbM315Zl6Ve-AKipHlfJ1aqYN5RVOzL-Y8bXmSbsJ0CuFXqCbK9FCPYz8wBKIyRiq7S6QM9yy8RZcQ6a4D6rLI4JeAUvmIjQ-sr9i8aqheBmkgZPsSxGujXy-a95QPUh3reAdJuyTcyceI_qIGsKGQKDYMt6w0twlCgjBlziCqKFz6X1b76ZugEAOYru_Fb0ESlSumNZHXP9QhC6ufmvZVzDjnWTNRZWY7cOwhgCYSc_5L0IdEySJdoyR-cgeo4EEy83rQIBfwdmqCY1P33n7oPPa-CB4q24UNSlTl6iztbYQTchILhDn4jrZTG5PQp4sJ5qcAqpUUTNyB-Wd_dafe3LdpNCTMcCUt01KGZF52nLDAHd-m-noOjxR8QhoDZkSVzRAKg3XnEKlPPNNvnuyErNkA3AQifFNpiXfhQPMlbxKH-grCvg6xvPAcLHs3tfZ2JxJ9uCcMDfLvuRv5atO7nC3LtHaTE8WoHyelkm1_CoG1XSD5omd2ahuk-ev0zE6hDGrSFRu3zJSf4spKPgAn-JK_hjR3eK-e-nf7jnTZNC79jDl7uvgl55dru_1jxUHLbj6IZO6-o_ZqIxIcY3q6tTh6UnxO8FyaTFMPxOI-eD8b5Jgu8oYoL556BomMgwQ4zlauLui_EjtfY3T90BsJFGtrep-Hf2suqSWwPWJL1oRG5fkHINXF4oVsDGEiaHpRdrUJM0S00tjinu3A5uahnK4cLln8uDEmuuEoOaYL0t85l1418azwXuAxiui48SQ99ESWcCAwFjAA1tYXN0ZXJfc2VjcmV0AEqY5Z4C7gCgErw6NoPqFWnv1hPza0eZ78Ef_H7nXiPB8AuTqLZDDk3chzjhyzeTjANDQ9ITN37GkogZO41eY4Nc-H__sSgvAcDDgwARYmlydGhkYXRlX2RhdGVpbnQASnbXhPkF2SyqXzhIZZVRlkfwSaCHpCiQZIdabXrMTeAW5bJhE6xszYCMq0EIaaXZ_9XbP61qtiJkbOz2n65Be6aIwhU55fcOj9RpAAl0aW1lc3RhbXAASsOw9hG1gUcCAUcalgdlDf0g6XXaAwNzEH8Id9YfY2L9NO9Mp_bRiC6xJ-iVsVt9YHFW26OWJKdp7pRmAWtgGLes2RNZbvPR69zgAARuYW1lAEp0DWphfK8tCbmpUZVU-LA6EIr9QrWSctDnn0UbhcWCLoYlWSN926YyeDnvxN7VzcCEGykmlMYKo-qoJKnrsD6L1A_N7s4PDDwEJgQASppRnLTXCuMfbKYOsuTZoLu1SgM0cmccRSYXEes0VkZ4mPAGtOu53VhCecQiLsG9nQAFyGQAm7WDFY5FSnZvsiZLtH3zwY-jtlPs",
+          "geProof": [
             "AAEwAEqNkLa-DWiPyz7yvsgIkUe_Z8Bg3lmrrbOwz2GsJrFoFKmFxFnwHa7K8JQewQq_E2zXhrZdzFMAXehG8rMlVaQlHXfajCg8fCe0AgBKbwJGfQCMSFiRztMJ4GTQ0X1H986sM6DVsMrj_uf18-t7Q7myW6A-AgzsYe0CV0Vua8OVfAuZwLzjm9F4-vy9fFm1Z-NcCi5snE0ASo40NwPcy2YpXLjV9tka5575_WB_gVjAwXv083dkJ7UfE2xhp-2c_3A9XX5PnQ-f-2osLFpY4hVmjzPwHvaEvL5SSvhuaaKPVvHmAErcW58H4GRjNwnecEVoBkxYj-FX3NBg7jQGMhnpnV10E_r7s_P8x-CehHOPB9JnrPk1oWpwhU-AEtK8QDzSSo_59cfL3fZP6j5WAAEF3AEqAv_r5rpeRgCMIoTR8cVc1SWcr0IdPjV15wXNlswLS7t08iIIT120q2ca5m0fpjJ41zHHbJN0z5gEn1oRXr4QmSzz8SY_vusw82VifrYcE3Agsvl4QAbQaXcKiiaqXm3Bj81ALV0O5ufg7cjPpViJcdmG99DcBQhoRNri04oYez7VF9CmyJNIb3n2si00Vka_vLzd4rkhbfIlLTxSwCdtd-ZdoQb7t5gZ2iZN861pL8oXtC0T1H3GqW8vI00m4c4aoYOqZ6yR10kljl1Rv7AKjgEvz7hxKqtUCnBtiFaVdvWbFIqpjXH7Cvz8UNXYsAvBXo3-MwB2iDqnanIFOEx6RSxWBaWj1WdezzWSoOyiK9n1q71BGUrWb87EaJWb_un2jWBQ-ZwSu4Q0lAEqAvo-taHIs_DjqgivmcPwsLza0w7dOsU4Ezs8BIa7OYqZtaBCJoI1376rYImztFRGUQW2auGTJAKf95_pAut-iOTIKufwrOhH6BxDxVtlaIvIdD30ZzJNMgM93Xv4N5MTEx4d24LYt0VYzSeLcjHlGe9ACs3ScQOHx5T_1WV063XmIGWFpox4hcuSqNBoDzt80U1ZPFFaygeyZFV4SYJrQyOJX2fZqQnYCTyjabYxFxP4aey13PGyvymjFpwOzmJE9J95EyiCWNXKQEuKrhq1z4GNkyTP-QVB6w-O86G8Dhtwv4WYOSxiOCddJ_iMDz_Quv9cmTePUsHIj2N2PKhBwlGT6WgM_tv1N98n4VnLLSPyYAaAJ1_iQ2eaL-I0GLxOSK-AE-eJmOWPmgEqA-Vijc2RKVKA9UZcHX_iGZq7gjjQDVl6GI-tPhqjV1D8tpHEWGa7cRCnnLONOEQPC7OrW-TamQTiOuJDkSuLQGKGaX46Y3KnfYPmPDNX_dlvBAZGa91Ep_SEgAF_lJJzw8aZF9DUf-VrDQj5Ceha09-CS1mIYcZdtw-1m6SCDRjpi1tZmFyHWwNNHHabmINuaa6sZ5KiO0rJvVm5qyq9n74BzaWo6vvk2dt0OrsdBrpYeXWA8SDqPk7aJn5xw0sHZBAzy39slMoe8SvF5bh9SOmREV2ewX1WbB5_pvMGh-wJNma7Il1YJPaSpsj0oRQwdBZmr-qizzTGq4g7amIifg9AQjEW8Z-iuUQRq0ojh0ah8l5VW2FaN53RT_dcfA05_krdFyQIq5i1zQEqAXRPTbBAFoqUCGCVrPHskEXrh_BBFx0868AkcgzbBQ7HgGvVYIM35GnlatRMfk9trvJ5tbGpqmfucibCsm--9giXXXznb3E8rmlcCA_mO08zDLRnjxzVP6RAcGJa87qAoIkP7OxGMqkTxXqbi6ui0Gf4T0wsWiJeZEaHxXuMnePQPve23ChCokQXa2QEM418sRPkO7EB51Xt2QrqZ_5ZErz7OFOL9mPRn49o5YoHj3Ip25uhXLpF8MOs0rxkV19poYgBOUH2TnUBTvuUl4-UnjKg2JompC-owr1DoRDPb2CCPF20xt6cUfc2W2uJ8QNEXi2enGfhddRiCp5mPujE6TKfaAl2PgdggqM-aXQAPgXOgDfl7JBt8oQv4foHRn9Zfh3eIKgnmbqSnQEqAnrq0hd40Mmj02Bmm6Azk1LTA8h7i2B2swyJK30J-tgXlTc2vPztE0cwI8zEPlMIFtDZOw1p7CXQwdw7nrnJA3vakAVMQzKQkTaZRJBNw7EOge0Rj-7d6rlbH88dEmKZVgsVe9dU_PXs8Af1u4FObS05IC2ITIegMue7fA-dsogV0L4VGSuy8BIzCaXXV3_sze5RES-cs0O5gfDF7wNSnGS4W0pdpYebkj8b5fKCarni3tUNfoWt_d_-_5v1Ubswozw2oMcqn8O4Z_IiYPoLm6rVLysI4v5WslQg03X7U-RiYyBfCwg_C8saiI6mLfoNiQX7VC4wS_W4F5O6SkQzK4W2mlyeWY3BCF4AoRsixDCVl1jn8rqVyxme0vU3-03ziL-tjrOamadjagIASnbXhPkF2SyqXzhIZZVRlkfwSaCHpCiQZIdabXrMTeAW5bJhE6xszYCMq0EIaaXZ_9XbP61qtiJkbOz2n65Be6aIwhU55fcOj9RpAwFdBt3RdJN10IXajQ9Z4wsFj3es-30l-SIjrdK2zf-2x9LIs_gWm4MSKA-o5y4-lMPv0xVqW9YuZzLEg-tFqugOnyLvrMW3ANERcWEqZRpettD8vl1tJAMN3EdwoZiOjSmTESVXsas-N9Qk0RYyjQXnbx1s3S1ZqZxr9fVrfw0h9OydaxvXY6zzR2eIOWU56hxv2MmaJkgnPsfbwMIQnRVWpvwaKDtVIqfrUpTANIqdEsKWXQtt0txrBEgBCBUtkufJa5eiwENTMLIyHLaN2e5ohYMWwY0l8tO8i_BEv_M0-Q5LtQf_-nfvaAKq5UdkYnxMScK8mk7XPlaUtVyWqW-BDH33UVSUEZRaKtN5wmQ9SAoN6LnKC-z4jl-RpC_-wVLP1uHVq9TSips3Pb4mv1vY7JkM1SSra-RItQWoPhV_aBkVUG4klqGpjfp4LNuF8uRJ0clwWxUMrSc1CdoBkgQFDwEBAjPOuLNhx-_RxxoLeqSkOViuVJqSuBXDpsrLEGg6wrdNNwJ3VC1nXaCBHELkl4rKOjbbCtMpRFrX0CnWCNVfvaDLntzgDFzPxEv3r-aB1dSTGqnJxcqNqYg8r7BIFwqrNvC99bSfGa7CnYrYhRUbKteE8tdTkWnnENyEYuCd-1Ih8zAAjdFuheBbS3CAVBhHVorldMuTw1tlII7piLq729j3EtGCFg9Rgs9bXavbFBTD2TgA0AwenNUi6DqHAvprymSjTY0de2SclSBAHRWqQA0QiuvYxiwLlvjLUtWLgUpJ4vqedx-4xTueubIIteXOSU08hBP_hwJ1AVCMmUF6mDUBAQEcifNZRAT1pjXIRXsV6lgcUTfYRz4t1ikQvolBTi5tnb4ePS5O3k4gqCdbsUp-3tokLii5fP-daqiIAdxcX1cHuzFQtjAw9tcVb_hq4jcZo3KP6nl-S4ZvtrLreM8A8jY5KR13RCYQtBEqJl11GUkrIsXQr8BYEoOkDL1VlatDvmhvUmAuFDa4klyps0kQrSdiYGExCBVPazxRMTUpmXXteUkUcaKfGK9Cdva6t5afA1_150NS1DGTb2uJASg8N07tIwm8YRj982Zkjk_EIMO_9-s4Xe4I9QNtcpbvQ_CswFGEJwyttkX_1amEshCYUq7YcNm4qCTsRd_WW4DLGTARAQECs6oxTPWi-VnDr4p9itsbqaMHOdd9iW726QeXaBgnbJqHWKV9eiCQEJNC24zkUZbXlB4CC6kkJ0pz3bWE7RT9Hyz_D73Pk9qiJk9-u-JjNCGlaAuGwrJh7XgSua-xOGYiLNSHnPHk-6comSJNdeU2UJ5RqKMpnvyAttHO0m9bFfxZ6smmjJdpkP3dkhJyLLuRu13fHFcTYOSO_ZWYXMCdmCfPc3CbU5mCj0VSbbAj6w_ZF6EyZEisS3JOu6VATJTWczBTrOlGYUKjouj14JiOI1EKAqAT7yCzNQEihmDd-8SuspeqilIHfSBQOrWcx0qybbImERULs6Ox8UlkdWKSHAEBAV_B08cenSBsIbIFVwRPPlSGlSbOwcfg6nUTy6XAsA__m43JX9QBagzSMHrK4-jfzNai75d4KqX1o_CD8DZiAZeehMhp3TmnMhso4-rCWS0rGIBMeJYjrcoSrErgWo8_zHYuNjWMIIL1PJSvtvz-ggo56-_VBeIgHxfoNui4cOX_e_EfVU4uZLhTtHwXC6rXM48bROp8cqHUs0WfLO3nW6ZmPCZjV80ijr_U0NyQBF_sOLs_hyqcM1VpSlGN44dEndH1-Jx_3BbjyX1YuvkgceaHZaX5Jnbc8SMbzVVTNDFWQ0fdd7YrZyBJc_7-32bdGvFYtVwtZhEHS-_wbGqHpEQBAQEnR0BBKTFzJRL9sfQTOkGPhs42bUbunOmr3_n6mQ1R0mnNicmCDuDFQch-c2vUJ05VLlxA_1GE42bw4KTL9x87N8PG-Q1tEcRsSaMAIf6jS5B8Mb1n7oh9DyYDYHUfOeSwVBz4PA2tKSayPdMgR2TVWNh3xVFPh5AkZhwHEAiE5NH6dY2m4OwdDSyOVBzIISOmwgBE7w_W02xBZ37Gjc9BJxua-vvmSXUi0w9OnYgE9VuikLwF3hAnAObiZsy9Q36axkvBGN8EYmDpD2HId_afPfhwXxv3z7XgWsgxvhZ1fFxi8bOdbob3DvdXqN4uIFwn65o8ENG_UHSGcNuwZYLw"
           ]
         }
@@ -59,8 +65,8 @@
     }
   ],
   "proof": {
-    "type": "AnonCredsAggregateProof2022",
+    "type": "AnonCredsPresentationProof2022",
     "nonce": "455903554639287921141579",
-    "data": "AAAgBHeJmA9ZnS68J3-Hn75c1C-pGCo0kexkOUzqjav3HHoBADMACMxw33exGTARAAsCs6oxTPVkdWKSHAAMAV_B08cenWxqh6REAAwBJ0dAQSlw27BlgvA"
+    "aggregated": "AAAgBHeJmA9ZnS68J3-Hn75c1C-pGCo0kexkOUzqjav3HHoBADMACMxw33exGTARAAsCs6oxTPVkdWKSHAAMAV_B08cenWxqh6REAAwBJ0dAQSlw27BlgvA"
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,115 @@
+{
+  "@version": 1.1,
+  "@protected": true,
+  "ac": "https://anoncreds.example/2022/ns#",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+  "attribute": {
+    "@id": "ac:attribute",
+    "@container": ["@index", "@set"],
+    "@index": "https://anoncreds.example/2022/ns#attributeName",
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "name": {
+        "@id": "ac:attributeName",
+        "@type": "xsd:string"
+      },
+      "encoding": {
+        "@id": "ac:attributeEncoding",
+        "@type": "@id"
+      },
+      "value": {
+        "@id": "ac:attributeValue",
+        "@type": "xsd:string"
+      }
+    }
+  },
+
+  "AnonCredsCredential": "ac:AnonCredsCredential",
+
+  "AnonCredsDefinition": {
+    "@id": "ac:AnonCredsDefinition",
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "schema": {
+        "@id": "ac:schema",
+        "@type": "@id"
+      },
+      "definition": {
+        "@id": "ac:definition",
+        "@type": "@id"
+      }
+    }
+  },
+
+  "AnonCredsPresentation": "ac:AnonCredsPresentation",
+
+  "AnonCredsPresentationProof2022": {
+    "@id": "ac:AnonCredsPresentationProof2022",
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "credential": {
+        "@id": "ac:credentialProof",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "encoding": {
+            "@id": "ac:attributeEncoding",
+            "@type": "@vocab",
+            "@context": {
+              "@version": 1.1,
+              "@protected": true,
+              "auto": "ac:autoEncoding"
+            }
+          },
+          "index": {
+            "@id": "ac:index",
+            "@type": "xsd:integer",
+            "@nest": "primary"
+          },
+          "mapping": {
+            "@id": "ac:attributeMapping",
+            "@type": "@json"
+          },
+          "eqProof": {
+            "@id": "ac:eqProof",
+            "@type": "xsd:string"
+          },
+          "geProof": {
+            "@id": "ac:geProof",
+            "@container": "@list",
+            "@type": "xsd:string"
+          }
+        }
+      },
+      "aggregated": {
+        "@id": "ac:aggregatedProof",
+        "@type": "xsd:string"
+      }
+    }
+  },
+
+  "CLSignature2022": {
+    "@id": "ac:CLSignature2022",
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "encoding": {
+        "@id": "ac:attributeEncoding",
+        "@type": "@vocab",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "auto": "ac:autoEncoding"
+        }
+      },
+      "signature": {
+        "@id": "ac:signature",
+        "@type": "xsd:string"
+      }
+    }
+  }
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
- Adds a draft JSON-LD context
- Uses a common structure for individual credential proofs and the aggregate proof
- Nests named attributes inside "attribute" to allow round-tripping

Credential schema and definition identifiers may need adjustment to be properly formatted as IDs? At the moment spaces are replaced with %20 to fix an error in the JSON-LD playground.

@swcurran 